### PR TITLE
Refactor: remove redundant security headers from production configuration

### DIFF
--- a/nginx/conf.d/prod.conf
+++ b/nginx/conf.d/prod.conf
@@ -7,23 +7,6 @@ upstream app_prod {
 server {
     listen 80;
     server_name connect.nitap.ac.in www.connect.nitap.ac.in;
-
-    # ===================================================================
-    # ==== SECURITY HEADERS ====
-    # ===================================================================
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-
-    # Content-Security-Policy (moved from next.config.js)
-    # - Explicitly allow connections to localhost (and 127.0.0.1) and websocket schemes
-    #   so client-side API requests and SSE/WebSocket connections during local/dev
-    #   usage are not blocked by the default-src fallback.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://lh3.googleusercontent.com https://avatars.githubusercontent.com; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; connect-src 'self' http://localhost http://127.0.0.1 http://localhost:3000 ws://localhost ws://127.0.0.1 wss://localhost wss://127.0.0.1;" always;
-
     location /_next/image {
         access_log off;
         proxy_pass http://app_prod$request_uri;


### PR DESCRIPTION
Eliminate unnecessary security headers from the production configuration to streamline the server setup.