### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/coding-pundit-nitap/campus-connect/security/code-scanning/2](https://github.com/coding-pundit-nitap/campus-connect/security/code-scanning/2)

In general, this problem is fixed by adding an explicit `permissions:` block either at the top level of the workflow (so it applies to all jobs) or within each job that should have constrained permissions. For a simple CI workflow that only checks out code and builds an image without pushing or modifying repo state, the least-privilege setup is `permissions: contents: read`, which allows reading the repository contents but not writing.

The best fix here, without changing any existing functionality, is to add a root-level `permissions:` block right after the `name:` line. This will apply to all jobs (including `build-prod-image`) unless a job overrides it. Specifically, in `.github/workflows/docker-image.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Docker Image CI`) and line 3 (`on:`), preserving indentation (no leading spaces for `permissions` since it’s top-level). No imports or other definitions are required; GitHub Actions understands the `permissions` key natively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
